### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     methods,
     Rcpp (>= 0.12.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     tidybayes (>= 3.0.0),
     dplyr (>= 1.0.7),
     rlang (>= 0.4.0),
@@ -36,8 +36,8 @@ LinkingTo:
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 Suggests:
     rmarkdown,
     knitr,

--- a/inst/stan/RW.stan
+++ b/inst/stan/RW.stan
@@ -2,9 +2,9 @@
 data {
   int<lower=1> TT;   // length of time series
   int<lower=1> K;   // J outcomes
-  int y[K, TT]; // outcome data
-  vector[TT] log_E[K];
-  int population[K, TT];
+  array[K, TT] int y; // outcome data
+  array[K] vector[TT] log_E;
+  array[K, TT] int population;
   int is_poisson;
   int is_binomial;
   vector[K] prior_eta_1_location;
@@ -14,12 +14,12 @@ data {
 }
 
 parameters {
-  vector<upper=0>[TT] eta[K];      // annual risk per group
+  array[K] vector<upper=0>[TT] eta;      // annual risk per group
   vector<lower=0>[K] sigma; // scale per group
 }
 
 transformed parameters {
-  vector[is_poisson ? TT : 0] mu[is_poisson ? K : 0];
+  array[is_poisson ? K : 0] vector[is_poisson ? TT : 0] mu;
   if (is_poisson) for (j in 1:K) mu[j] = log_E[j] + eta[j];
 }
 
@@ -34,8 +34,8 @@ model {
 }
 
 generated quantities {
-  vector[TT] rate[K];
-  vector[TT] log_lik[K];
+  array[K] vector[TT] rate;
+  array[K] vector[TT] log_lik;
   for (j in 1:K) {
     if (is_poisson) {
     rate[j] = exp( eta[j] );

--- a/inst/stan/RWCorr.stan
+++ b/inst/stan/RWCorr.stan
@@ -2,9 +2,9 @@
 data {
   int<lower=1> TT;   // length of time series
   int<lower=1> K;   // J outcomes
-  int y[TT, K];     // outcome datda
-  int population[TT, K];  
-  vector[K] log_E[TT];  // log population at risk
+  array[TT, K] int y;     // outcome datda
+  array[TT, K] int population;  
+  array[TT] vector[K] log_E;  // log population at risk
   int is_poisson;
   int is_binomial;
   vector[K] prior_eta_1_location;
@@ -16,14 +16,14 @@ data {
 
 parameters {
   vector[K] eta_1;
-  vector[K] z[TT];             // d.eta  
+  array[TT] vector[K] z;             // d.eta  
   vector<lower=0>[K] sigma; // scale per group
   cholesky_factor_corr[K] L_Omega;   // correlation between groups
 }
 
 transformed parameters {
-  vector[K] eta[TT];           // annual risk per group  
-  vector[is_poisson ? K : 0] mu_y[is_poisson ? TT : 0];  
+  array[TT] vector[K] eta;           // annual risk per group  
+  array[is_poisson ? TT : 0] vector[is_poisson ? K : 0] mu_y;  
   matrix[K, K] L;
   L = diag_pre_multiply(sigma, L_Omega);
   eta[1] = eta_1;
@@ -51,8 +51,8 @@ model {
 
 generated quantities {
   matrix[K, K] Omega = tcrossprod(L_Omega); 
-  vector[TT] rate[K];
-  vector[TT] log_lik[K];
+  array[K] vector[TT] rate;
+  array[K] vector[TT] log_lik;
   if (is_poisson) {
     for (t in 1:TT) {
       for (j in 1:K) {


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
